### PR TITLE
Moved Notification Event for Inventory Wipe

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -22,10 +22,10 @@ RegisterNetEvent('hospital:server:RespawnAtHospital', function()
 		if Config.WipeInventoryOnRespawn then
 			Player.Functions.ClearInventory()
 			exports.oxmysql:execute('UPDATE players SET inventory = ? WHERE citizenid = ?', { json.encode({}), Player.PlayerData.citizenid })
+			TriggerClientEvent('QBCore:Notify', src, 'All your possessions have been taken..', 'error')
 		end
 		Player.Functions.RemoveMoney("bank", Config.BillCost, "respawned-at-hospital")
 		TriggerEvent('qb-bossmenu:server:addAccountMoney', "ambulance", Config.BillCost)
-		TriggerClientEvent('QBCore:Notify', src, 'All your possessions have been taken..', 'error')
 		TriggerClientEvent('hospital:client:SendBillEmail', src, Config.BillCost)
 		return
 	end


### PR DESCRIPTION
**Fix**
Very small fix but this moves the notification into the if statement as when Config.WipeInventoryOnRespawn is set to false, the message is displayed when it should be displayed when your inventory gets wiped (Config.WipeInventoryOnRespawn = true).

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes 
