### PR TITLE
remove: duplicated death dispatch calls

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -66,6 +66,8 @@ function SetLaststand(bool, spawn)
         end
 
         InLaststand = true
+		
+	TriggerServerEvent('hospital:server:ambulanceAlert', 'Civilian Down')
 
         CreateThread(function()
             while InLaststand do
@@ -104,7 +106,6 @@ function SetLaststand(bool, spawn)
         CanBePickuped = false
         LaststandTime = 0
     end
-    TriggerServerEvent('hospital:server:ambulanceAlert', 'Civilian Down')
     TriggerServerEvent("hospital:server:SetLaststandStatus", bool)
 end
 


### PR DESCRIPTION
**Describe Pull request**
Remove's the duplicated notification when a Civilian dies.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
