### PR TITLE
Allow for multiple hospitals to be used at once

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -112,12 +112,16 @@ local function GetAvailableBed(bedId)
     if bedId == nil then
         for k, v in pairs(Config.Locations["beds"]) do
             if not Config.Locations["beds"][k].taken then
-                retval = k
+		if #(pos - vector3(Config.Locations["beds"][k].coords.x, Config.Locations["beds"][k].coords.y, Config.Locations["beds"][k].coords.z)) < 500 then
+                	retval = k
+		end
             end
         end
     else
         if not Config.Locations["beds"][bedId].taken then
-            retval = bedId
+		if #(pos - vector3(Config.Locations["beds"][bedId].coords.x, Config.Locations["beds"][bedId].coords.y, Config.Locations["beds"][bedId].coords.z))  < 500 then
+            		retval = bedId
+		end
         end
     end
     return retval
@@ -894,44 +898,45 @@ CreateThread(function()
         sleep = 1000
         if LocalPlayer.state['isLoggedIn'] then
             local pos = GetEntityCoords(PlayerPedId())
-
-            if #(pos - Config.Locations["checking"]) < 1.5 then
-                sleep = 7
-                if doctorCount >= Config.MinimalDoctors then
-                    DrawText3D(Config.Locations["checking"].x, Config.Locations["checking"].y, Config.Locations["checking"].z, "~g~E~w~ - Call doctor")
-                else
-                    DrawText3D(Config.Locations["checking"].x, Config.Locations["checking"].y, Config.Locations["checking"].z, "~g~E~w~ - Check in")
-                end
-                if IsControlJustReleased(0, 38) then
+            for k, checkins in pairs(Config.Locations["checking"]) do
+                if #(pos - checkins) < 1.5 then
+                    sleep = 7
                     if doctorCount >= Config.MinimalDoctors then
-                        TriggerServerEvent("hospital:server:SendDoctorAlert")
+                        DrawText3D(checkins.x, checkins.y, checkins.z, "~g~E~w~ - Call doctor")
                     else
-                        TriggerEvent('animations:client:EmoteCommandStart', {"notepad"})
-                        QBCore.Functions.Progressbar("hospital_checkin", "Checking in..", 2000, false, true, {
-                            disableMovement = true,
-                            disableCarMovement = true,
-                            disableMouse = false,
-                            disableCombat = true,
-                        }, {}, {}, {}, function() -- Done
-                            TriggerEvent('animations:client:EmoteCommandStart', {"c"})
-                            local bedId = GetAvailableBed()
-                            if bedId then
-                                TriggerServerEvent("hospital:server:SendToBed", bedId, true)
-                            else
-                                QBCore.Functions.Notify("Beds are occupied..", "error")
-                            end
-                        end, function() -- Cancel
-                            TriggerEvent('animations:client:EmoteCommandStart', {"c"})
-                            QBCore.Functions.Notify("Checking in failed!", "error")
-                        end)
+                        DrawText3D(checkins.x, checkins.y, checkins.z, "~g~E~w~ - Check in")
                     end
-                end
-            elseif #(pos - Config.Locations["checking"]) < 4.5 then
-                sleep = 7
-                if doctorCount >= Config.MinimalDoctors then
-                    DrawText3D(Config.Locations["checking"].x, Config.Locations["checking"].y, Config.Locations["checking"].z, "Call")
-                else
-                    DrawText3D(Config.Locations["checking"].x, Config.Locations["checking"].y, Config.Locations["checking"].z, "Check in")
+                    if IsControlJustReleased(0, 38) then
+                        if doctorCount >= Config.MinimalDoctors then
+                            TriggerServerEvent("hospital:server:SendDoctorAlert")
+                        else
+                            TriggerEvent('animations:client:EmoteCommandStart', {"notepad"})
+                            QBCore.Functions.Progressbar("hospital_checkin", "Checking in..", 2000, false, true, {
+                                disableMovement = true,
+                                disableCarMovement = true,
+                                disableMouse = false,
+                                disableCombat = true,
+                            }, {}, {}, {}, function() -- Done
+                                TriggerEvent('animations:client:EmoteCommandStart', {"c"})
+                                local bedId = GetAvailableBed()
+                                if bedId then
+                                    TriggerServerEvent("hospital:server:SendToBed", bedId, true)
+                                else
+                                    QBCore.Functions.Notify("Beds are occupied..", "error")
+                                end
+                            end, function() -- Cancel
+                                TriggerEvent('animations:client:EmoteCommandStart', {"c"})
+                                QBCore.Functions.Notify("Checking in failed!", "error")
+                            end)
+                        end
+                    end
+                elseif #(pos - checkins) < 4.5 then
+                    sleep = 7
+                    if doctorCount >= Config.MinimalDoctors then
+                        DrawText3D(checkins.x, checkins.y, checkins.z, "Call")
+                    else
+                        DrawText3D(checkins.x, checkins.y, checkins.z, "Check in")
+                    end
                 end
             end
 


### PR DESCRIPTION
Allows for the ability to draw multiple check-in arrows. Makes sure a player isn't sent to a bed in another hospital by checking the distance to the nearest bed and making sure it's not too far.
