### PR TITLE
fix falling out of vehicle

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -27,7 +27,23 @@ function OnDeath()
             local pos = GetEntityCoords(player)
             local heading = GetEntityHeading(player)
 
-            NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
+            local ped = PlayerPedId()
+            if IsPedInAnyVehicle(ped) then
+                local veh = GetVehiclePedIsIn(ped)
+                local vehseats = GetVehicleModelNumberOfSeats(GetHashKey(GetEntityModel(veh)))
+                print(ped, veh, vehseats)
+                for i = -1, vehseats do
+                    local occupant = GetPedInVehicleSeat(veh, i)
+                    if occupant == ped then
+                        seat = i
+                        NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
+                        SetPedIntoVehicle(ped, veh, seat)
+                    end
+                end
+            else
+                NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
+            end
+			
             SetEntityInvincible(player, true)
             SetEntityHealth(player, GetEntityMaxHealth(player))
             if IsPedInAnyVehicle(player, false) then


### PR DESCRIPTION
added vehicle check at the resurrection native used to set the players ped into a dead state, if a player is in a vehicle, the check will then run a short for loop based on how many seats are in the peds current vehicle, and when it finds the ped it breaks the loop. once it has found the seat the player is in, it will then run the resurrection event, and then place them into the vehicle seat they were sitting in prior.

have tried it in multiple seats, including every seat of a city bus, and it correctly places the ped. and when hanging outside of a vehicle, or while riding in an open seat, the ped will correctly ragdoll off the side, or be set into the downed state as normal in the bed of an open vehicle. 

merry christmas, no more falling out of cars when you bleed out