### PR TITLE
fixed falling out of vehicle

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -53,7 +53,23 @@ function SetLaststand(bool, spawn)
 
         LaststandTime = Laststand.ReviveInterval
 
-        NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
+        local ped = PlayerPedId()
+        if IsPedInAnyVehicle(ped) then
+
+            local veh = GetVehiclePedIsIn(ped)
+            local vehseats = GetVehicleModelNumberOfSeats(GetHashKey(GetEntityModel(veh)))
+            for i = -1, vehseats do
+                local occupant = GetPedInVehicleSeat(veh, i)
+                if occupant == ped then
+                    seat = i
+                    NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
+                    SetPedIntoVehicle(ped, veh, seat)
+                end
+            end
+        else
+            NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
+        end		
+		
         SetEntityHealth(ped, 150)
 
         if IsPedInAnyVehicle(ped, false) then


### PR DESCRIPTION
same as the fix in dead.lua, this places a vehicle check on the resurrection event that resets a killed player ped. if the ped is in a vehicle it will then search through the vehicle seats for the ped, and place them into that seat after performing the resurrection event using a short for loop that runs for the number of seats of the vehicle.

no print this time

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
