### PR TITLE
Update job.lua

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -123,7 +123,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
         QBCore.Functions.GetPlayerData(function(PlayerData)
             PlayerJob = PlayerData.job
             onDuty = PlayerData.job.onduty
-            SetPedArmour(ped, PlayerData.metadata["armor"])
+            SetPedArmour(PlayerPedId(), PlayerData.metadata["armor"])
             if (not PlayerData.metadata["inlaststand"] and PlayerData.metadata["isdead"]) then
                 deathTime = Laststand.ReviveInterval
                 OnDeath()


### PR DESCRIPTION
The ped variable that is being referenced here is not always correct. This ensures that the armor is always put on the correct id.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

I'm not sure why the original ped variable doesn't work, but I was having issues with the armor being set to 0 when the player is loaded in. Changing ped to PlayerPedId() made sure I always put the armor on, regardless of loading in cold or loading in from a logout.


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- My QBCore is not updated
- Does your code fit the style guidelines? [yes/no]
- Yes
- Does your PR fit the contribution guidelines? [yes/no]
- Yes
