### PR TITLE
Fixed CheckWeaponDamage

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -344,7 +344,7 @@ end
 local function CheckWeaponDamage(ped)
     local detected = false
     for k, v in pairs(QBCore.Shared.Weapons) do
-        if HasPedBeenDamagedByWeapon(ped, GetHashKey(k), 0) then
+        if HasPedBeenDamagedByWeapon(ped, k, 0) then
             detected = true
             if not IsInDamageList(k) then
                 TriggerEvent('chat:addMessage', {


### PR DESCRIPTION
**Describe Pull request**
Weapons in QBCore.Shared.Weapons are already set as a hash making it so that HasPedBeenDamagedByWeapon always returns false

If your PR is to fix an issue mention that issue here
Fixed HasPedBeenDamagedByWeapon always returning false

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
