### PR TITLE
Fix overlapping drawtext / Enable G key

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -150,6 +150,7 @@ CreateThread(function()
             EnableControlAction(0, 213, true)
             EnableControlAction(0, 249, true)
             EnableControlAction(0, 46, true)
+            EnableControlAction(0, 47, true)
 
             if isDead then
                 if not isInHospitalBed then
@@ -188,9 +189,9 @@ CreateThread(function()
                 else
                     DrawTxt(0.845, 1.44, 1.0, 1.0, 0.6, Lang:t('info.bleed_out_help', {time = math.ceil(LaststandTime)}), 255, 255, 255, 255)
                     if not emsNotified then
-                        DrawTxt(0.91, 1.40, 1.0, 1.0, 0.6, Lang:t('info.request_help'), 255, 255, 255, 255)
+                        DrawTxt(0.91, 1.44, 1.0, 1.1, 0.6, Lang:t('info.request_help'), 255, 255, 255, 255)
                     else
-                        DrawTxt(0.90, 1.40, 1.0, 1.0, 0.6, Lang:t('info.help_requested'), 255, 255, 255, 255)
+                        DrawTxt(0.90, 1.44, 1.0, 1.1, 0.6, Lang:t('info.help_requested'), 255, 255, 255, 255)
                     end
 
                     if IsControlJustPressed(0, 47) and not emsNotified then


### PR DESCRIPTION
When going into last stand, after 60 seconds you get prompted with `Press G to Request Help` (Line 192), but this overlaps Your Bleed out drawtext (Line 190). You also cannot press G to send EMS an alert as the G key is disabled. I have fixed the overlapping of the drawtext. I also enabled the G key (line 153) so that people in last stand can send an alert to ems because currently the G key does not work as its disabled.

Before:
https://i.imgur.com/YvxDaPC.png
After:
https://i.imgur.com/tD5LbJ6.png

Before:
https://i.imgur.com/Sf9Jx8Q.png
After:
https://i.imgur.com/QDQDiCC.png

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes
- Does your code fit the style guidelines? [yes/no]
yes
- Does your PR fit the contribution guidelines? [yes/no]
yes
