### PR TITLE
fix(client/job): return string instead of table

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -203,7 +203,7 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
                             TriggerEvent('chat:addMessage', {
                                 color = { 255, 0, 0},
                                 multiline = false,
-                                args = {Lang:t('info.status'), QBCore.Shared.Weapons[v]}
+                                args = {Lang:t('info.status'), QBCore.Shared.Weapons[v].damagereason}
                             })
                         end
                     elseif result["BLEED"] > 0 then


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue of the status check returning a table identifier instead of the expected string

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
