### PR TITLE
Doctors clock out/check in fix

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -132,7 +132,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 end)
 
 RegisterNetEvent('QBCore:Client:SetDuty', function(duty)
-    if PlayerJob.name == 'ambulance' and duty ~= onDuty then
+    if PlayerJob.name == 'ambulance' then
         if duty then
             TriggerServerEvent("hospital:server:AddDoctor", PlayerJob.name)
         else


### PR DESCRIPTION
**Describe Pull request**
Removing this part fixes the issue where if the doctors clock out or log out, people get the option to alert a doctor instead of checking in. Not sure what purpose this part serves, didn't seem to affect anything else and fixed the issue, so thought I'd PR it. First time doing so, sorry for any mistakes.

If your PR is to fix an issue mention that issue here:
This is a potential fix for #170 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes.
- Does your code fit the style guidelines? [yes/no]
Hope so, first PR.
- Does your PR fit the contribution guidelines? [yes/no]
Don't see a reason why it wouldn't.
