### PR TITLE
Implement check if player is not in hospital bed

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -963,8 +963,10 @@ else
             local bedCombo = ComboZone:Create(bedPoly, {name = "bedCombo", debugPoly = false})
             bedCombo:onPlayerInOut(function(isPointInside)
                 if isPointInside then
-                    exports['qb-core']:DrawText(Lang:t('text.lie_bed'), 'left')
-                    CheckInControls("beds")
+                    if not isInHospitalBed then
+                        exports['qb-core']:DrawText(Lang:t('text.lie_bed'), 'left')
+                        CheckInControls("beds")
+                    end
                 else
                     listen = false
                     exports['qb-core']:HideText()


### PR DESCRIPTION
When a player is lying in a hospital bed after checking in, they run the risk of accidentally moving to/lying in another close hospital bed and getting charged a second time when pressing 'E' to exit their bed. Ensuring that a player is not already in a hospital bed while pressing 'E' near an open one prevents this from happening.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes