### PR TITLE
Ragdoll for last stand

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -48,8 +48,12 @@ function OnDeath()
                 loadAnimDict("veh@low@front_ps@idle_duck")
                 TaskPlayAnim(player, "veh@low@front_ps@idle_duck", "sit", 1.0, 1.0, -1, 1, 0, 0, 0, 0)
             else
-                loadAnimDict(deadAnimDict)
-                TaskPlayAnim(player, deadAnimDict, deadAnim, 1.0, 1.0, -1, 1, 0, 0, 0, 0)
+                if not Config.Ragdoll then
+                    loadAnimDict(deadAnimDict)
+                    TaskPlayAnim(player, deadAnimDict, deadAnim, 1.0, 1.0, -1, 1, 0, 0, 0, 0)
+                else
+                    RagdollLoop()
+                end
             end
             TriggerServerEvent('hospital:server:ambulanceAlert', Lang:t('info.civ_died'))
         end

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -38,6 +38,15 @@ local function LoadAnimation(dict)
     end
 end
 
+local function RagdollLoop()
+    CreateThread(function()
+        while InLaststand do
+            Wait(5)
+            SetPedToRagdoll(PlayerPedId(), 1000, 1000, 0, 0, 0, 0)
+        end
+    end)
+end
+
 function SetLaststand(bool)
     local ped = PlayerPedId()
     if bool then
@@ -61,14 +70,18 @@ function SetLaststand(bool)
             NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
         end
         SetEntityHealth(ped, 150)
+        InLaststand = true
         if IsPedInAnyVehicle(ped, false) then
             LoadAnimation("veh@low@front_ps@idle_duck")
             TaskPlayAnim(ped, "veh@low@front_ps@idle_duck", "sit", 1.0, 8.0, -1, 1, -1, false, false, false)
         else
-            LoadAnimation(lastStandDict)
-            TaskPlayAnim(ped, lastStandDict, lastStandAnim, 1.0, 8.0, -1, 1, -1, false, false, false)
+            if not Config.Ragdoll then
+                LoadAnimation(lastStandDict)
+                TaskPlayAnim(ped, lastStandDict, lastStandAnim, 1.0, 8.0, -1, 1, -1, false, false, false)
+            else
+                RagdollLoop()
+            end
         end
-        InLaststand = true
         TriggerServerEvent('hospital:server:ambulanceAlert', Lang:t('info.civ_down'))
         CreateThread(function()
             while InLaststand do

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -38,9 +38,9 @@ local function LoadAnimation(dict)
     end
 end
 
-local function RagdollLoop()
+function RagdollLoop()
     CreateThread(function()
-        while InLaststand do
+        while InLaststand or isDead do
             Wait(5)
             SetPedToRagdoll(PlayerPedId(), 1000, 1000, 0, 0, 0, 0)
         end

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,7 @@ Config.DocCooldown = 1 -- Cooldown between doctor calls allowed, in minutes
 Config.WipeInventoryOnRespawn = true -- Enable or disable removing all the players items when they respawn at the hospital
 Config.Helicopter = "polmav" -- Helicopter model that players with the ambulance job can use
 Config.BillCost = 2000 -- Price that players are charged for using the hospital check-in system
+Config.Ragdoll = true -- ragdoll for death emote
 Config.DeathTime = 300 -- How long the timer is for players to bleed out completely and respawn at the hospital
 Config.PainkillerInterval = 60 -- Set the length of time painkillers last (per one)
 Config.HealthDamage = 5 -- Minumum damage done to health before checking for injuries


### PR DESCRIPTION
This allows a config option to be switched and on last stand ragdoll will be active till the end of last stand. Tested putting people in and out of vehicles, escorting, and reviving.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/] (Be honest)
- Does your code fit the style guidelines? [yes/]
- Does your PR fit the contribution guidelines? [yes/]
