### PR TITLE
[BUG] Fix Jailbeds

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -53,10 +53,20 @@ local function GetAvailableBed(bedId)
     local pos = GetEntityCoords(PlayerPedId())
     local retval = nil
     if bedId == nil then
-        for k, _ in pairs(Config.Locations["beds"]) do
-            if not Config.Locations["beds"][k].taken then
-                if #(pos - vector3(Config.Locations["beds"][k].coords.x, Config.Locations["beds"][k].coords.y, Config.Locations["beds"][k].coords.z)) < 500 then
+        if QBCore.Functions.GetPlayerData().metadata["injail"] > 0 then
+            for k, _ in pairs(Config.Locations["jailbeds"]) do
+                if not Config.Locations["jailbeds"][k].taken then
+                    if #(pos - vector3(Config.Locations["jailbeds"][k].coords.x, Config.Locations["jailbeds"][k].coords.y, Config.Locations["jailbeds"][k].coords.z)) < 500 then
                         retval = k
+                    end
+                end
+            end
+        else
+            for k, _ in pairs(Config.Locations["beds"]) do
+                if not Config.Locations["beds"][k].taken then
+                    if #(pos - vector3(Config.Locations["beds"][k].coords.x, Config.Locations["beds"][k].coords.y, Config.Locations["beds"][k].coords.z)) < 500 then
+                        retval = k
+                    end
                 end
             end
         end

--- a/server/main.lua
+++ b/server/main.lua
@@ -21,11 +21,19 @@ end)
 RegisterNetEvent('hospital:server:SendToBed', function(bedId, isRevive)
 	local src = source
 	local Player = QBCore.Functions.GetPlayer(src)
-	TriggerClientEvent('hospital:client:SendToBed', src, bedId, Config.Locations["beds"][bedId], isRevive)
-	TriggerClientEvent('hospital:client:SetBed', -1, bedId, true)
-	Player.Functions.RemoveMoney("bank", Config.BillCost , "respawned-at-hospital")
+	if Player.PlayerData.metadata["injail"] > 0 then
+		TriggerClientEvent('hospital:client:SendToBed', src, bedId, Config.Locations["jailbeds"][bedId], isRevive)
+		TriggerClientEvent('hospital:client:SetBed2', -1, bedId, true)
+		Player.Functions.RemoveMoney("bank", Config.BillCost , "respawned-at-hospital")
 		exports['qb-management']:AddMoney("ambulance", Config.BillCost)
-	TriggerClientEvent('hospital:client:SendBillEmail', src, Config.BillCost)
+		TriggerClientEvent('hospital:client:SendBillEmail', src, Config.BillCost)
+	else
+		TriggerClientEvent('hospital:client:SendToBed', src, bedId, Config.Locations["beds"][bedId], isRevive)
+		TriggerClientEvent('hospital:client:SetBed', -1, bedId, true)
+		Player.Functions.RemoveMoney("bank", Config.BillCost , "respawned-at-hospital")
+		exports['qb-management']:AddMoney("ambulance", Config.BillCost)
+		TriggerClientEvent('hospital:client:SendBillEmail', src, Config.BillCost)
+	end
 end)
 
 RegisterNetEvent('hospital:server:RespawnAtHospital', function()


### PR DESCRIPTION
When you want to check in when you are jailed and inside the jail it says that all beds are occupied.
With this PR it looks if you are jailed and gets the nearby beds from Config.Locations['jailbeds'] instead of the hospital beds.

This is a fix for : #248

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
Does your code fit the style guidelines? Yes
Does your PR fit the contribution guidelines? Yes