### PR TITLE
carry laststand / dead players

### DIFF
--- a/locales/ar.lua
+++ b/locales/ar.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'ليس لديك ما يكفي من المال عليك',
         cant_help = 'لا يمكنك مساعدة هذا الشخص',
         not_ems = 'لست بمسعف',
-        not_online = 'اللاعب غير متصل'
+        not_online = 'اللاعب غير متصل',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'لقد أحيت شخصًا',

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Du hast nicht genügend Geld bei dir...',
         cant_help = 'Du kannst dieser Person nicht helfen...',
         not_ems = 'Du bist kein Rettungsdienst',
-        not_online = 'Spieler nicht online'
+        not_online = 'Spieler nicht online',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Du hast eine Person wiederbelebt',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'You don\'t have enough money on you...',
         cant_help = 'You can\'t help this person...',
         not_ems = 'You are not EMS or not signed in',
-        not_online = 'Player Not Online'
+        not_online = 'Player Not Online',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'You revived a person',

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'No tienes suficiente dinero...',
         cant_help = 'No puedes ayudar a esta persona...',
         not_ems = 'No eres EMS',
-        not_online = 'El jugador no está en línea'
+        not_online = 'El jugador no está en línea',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Persona reanimada',

--- a/locales/fi.lua
+++ b/locales/fi.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Sinulla ei ole tarpeeksi rahaa mukana...',
         cant_help = 'Henkilöä ei voi enään auttaa...',
         not_ems = 'Et ole ensihoitaja',
-        not_online = 'Pelaaja ei ole onlinessa'
+        not_online = 'Pelaaja ei ole onlinessa',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Elvytit henkilön!',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Vous n\'avez pas assez d\'argent sur vous...',
         cant_help = 'Vous ne pouvez pas aider cette personne...',
         not_ems = 'Vous n\'êtes pas EMS',
-        not_online = 'Le joueur n\'est pas connecté'
+        not_online = 'Le joueur n\'est pas connecté',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Vous avez réanimé quelqu\'un',

--- a/locales/is.lua
+++ b/locales/is.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Þú átt ekki nægan pening á þér...',
         cant_help = 'Þú getur ekki hjálpað þessari manneskju...',
         not_ems = 'Þú ert ekki EMS eða ekki skráður inn',
-        not_online = 'Spilari ekki á netinu'
+        not_online = 'Spilari ekki á netinu',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Þú endurlífgaðir mann',

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Non hai abbastanza soldi...',
         cant_help = 'Non puoi aiutare questa persona...',
         not_ems = 'Non sei EMS o non sei in servizio',
-        not_online = 'Giocatore offline'
+        not_online = 'Giocatore offline',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Hai rianimato una persona',

--- a/locales/pt-br.lua
+++ b/locales/pt-br.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Você não tem dinheiro suficiente com você...',
         cant_help = 'Você não pode ajudar essa pessoa...',
         not_ems = 'Você não faz parte do Serviço Médico Emergencial(EMS) ou não está em serviço',
-        not_online = 'Jogador não está online'
+        not_online = 'Jogador não está online',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Você reviveu uma pessoa',

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Não tens dinheiro suficiente contigo...',
         cant_help = 'Não podes ajudar esta pessoa...',
         not_ems = 'Não pertences ao EMS',
-        not_online = 'Jogador Desligado'
+        not_online = 'Jogador Desligado',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Reviveste uma pessoa',

--- a/locales/sk.lua
+++ b/locales/sk.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Nemáš dostatok peňazí...',
         cant_help = 'Nemôžeš pomôcť tejto osobe...',
         not_ems = 'Nie si EMS',
-        not_online = 'Hráč nie je online'
+        not_online = 'Hráč nie je online',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Oživil si osobu',

--- a/locales/vn.lua
+++ b/locales/vn.lua
@@ -11,7 +11,8 @@ local Translations = {
         not_enough_money = 'Bạn không có đủ tiền...',
         cant_help = 'Bạn không thể cứu người này...',
         not_ems = 'Bạn không phải Bác sĩ',
-        not_online = 'Người chơi không trực tuyến'
+        not_online = 'Người chơi không trực tuyến',
+        not_dead = 'There is no dead player nearby!'
     },
     success = {
         revived = 'Bạn đã hồi sinh một người',

--- a/server/main.lua
+++ b/server/main.lua
@@ -294,6 +294,43 @@ RegisterNetEvent('hospital:server:resetHungerThirst', function()
 	TriggerClientEvent('hud:client:UpdateNeeds', source, 100, 100)
 end)
 
+RegisterNetEvent('qb-ambulancejob:server:DragPlayer', function(playerId)
+    local src = source
+    local playerPed = GetPlayerPed(src)
+    local targetPed = GetPlayerPed(playerId)
+    local playerCoords = GetEntityCoords(playerPed)
+    local targetCoords = GetEntityCoords(targetPed)
+    if #(playerCoords - targetCoords) > 4.5 then return DropPlayer(src, "Attempted exploit abuse") end
+
+    local Player = QBCore.Functions.GetPlayer(source)
+    local EscortPlayer = QBCore.Functions.GetPlayer(playerId)
+    if not Player or not EscortPlayer then return end
+	print("Dragging player "..tostring(EscortPlayer.PlayerData.source))
+    -- if Player.PlayerData.job.type == "EMS" then
+        TriggerClientEvent("qb-ambulancejob:client:GetDragged", EscortPlayer.PlayerData.source, Player.PlayerData.source)
+    -- else
+    --     TriggerClientEvent('QBCore:Notify', src, Lang:t("error.not_dead"), 'error')
+    -- end
+end)
+
+RegisterNetEvent('qb-ambulancejob:server:PutPlayerInVehicle', function(playerId)
+    local src = source
+    local playerPed = GetPlayerPed(src)
+    local targetPed = GetPlayerPed(playerId)
+    local playerCoords = GetEntityCoords(playerPed)
+    local targetCoords = GetEntityCoords(targetPed)
+    if #(playerCoords - targetCoords) > 2.5 then return DropPlayer(src, "Attempted exploit abuse") end
+
+    local EscortPlayer = QBCore.Functions.GetPlayer(playerId)
+    if not QBCore.Functions.GetPlayer(src) or not EscortPlayer then return end
+
+    if EscortPlayer.PlayerData.metadata["inlaststand"] or EscortPlayer.PlayerData.metadata["isdead"] then
+        TriggerClientEvent("qb-ambulancejob:client:PutInVehicle", EscortPlayer.PlayerData.source)
+    else
+        TriggerClientEvent('QBCore:Notify', src, Lang:t("error.not_dead"), 'error')
+    end
+end)
+
 -- Callbacks
 
 QBCore.Functions.CreateCallback('hospital:GetDoctors', function(_, cb)


### PR DESCRIPTION
**Describe Pull request**

With this pr you can carry wounded people that are in last stand or dead and put them in vehicle or take them out.
This can be done by anyone but the other player needs to be in last stand or dead.

Add this at the end of your radialmenu to get it working from there:

```lua
[3] = {
        id = 'escortoptions',
        title = 'Interactions',
        icon = 'user-doctor',
        items = {
            {
                id = 'escort',
                title = 'Escort',
                icon = 'user-group',
                type = 'client',
                event = 'qb-ambulancejob:client:DragPlayer',
                shouldClose = true
            }, {
                id = 'putinveh',
                title = 'Put In Vehicle',
                icon = 'car-side',
                type = 'client',
                event = 'qb-ambulancejob:client:PutPlayerInVehicle',
                shouldClose = true
            }, {
                id = 'takeoutveh',
                title = 'Take From Vehicle',
                icon = 'car-side',
                type = 'client',
                event = 'qb-ambulancejob:client:SetPlayerOutVehicle',
                shouldClose = true
            }
        }
    }
```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [Yes]
- Does your code fit the style guidelines? [Yes]
- Does your PR fit the contribution guidelines? [Yes]
