### PR TITLE
[Feature] Get Death Status of any player

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -307,6 +307,15 @@ QBCore.Functions.CreateCallback('hospital:GetDoctors', function(_, cb)
 	cb(amount)
 end)
 
+QBCore.Functions.CreateCallback('hospital:server:getDeathStatus', function(_, cb, playerId)
+    local Player = QBCore.Functions.GetPlayer(playerId)
+    local status = {
+        dead = Player.PlayerData.metadata.isdead,
+        lastStand = Player.PlayerData.metadata.inlaststand
+    }
+    cb(status)
+end)
+
 QBCore.Functions.CreateCallback('hospital:GetPlayerStatus', function(_, cb, playerId)
 	local Player = QBCore.Functions.GetPlayer(playerId)
 	local injuries = {}


### PR DESCRIPTION
callback returns status.dead if dead and status.lastStand if in last stand

I have used this in my police job to check prior to robbing a different player. A fellow community member asked me for a config option so a player could be robbed in last stand.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
