### PR TITLE
Fix death event not persisting when player disconnects

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -110,7 +110,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
             onDuty = PlayerData.job.onduty
             SetPedArmour(PlayerPedId(), PlayerData.metadata["armor"])
             if (not PlayerData.metadata["inlaststand"] and PlayerData.metadata["isdead"]) then
-                deathTime = Laststand.ReviveInterval
+                deathTime = Config.ReviveInterval
                 OnDeath()
                 DeathTimer()
             elseif (PlayerData.metadata["inlaststand"] and not PlayerData.metadata["isdead"]) then

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-AmbulanceJob'
-version '1.2.3'
+version '1.2.4'
 
 shared_scripts {
 	'@qb-core/shared/locale.lua',


### PR DESCRIPTION
**Describe Pull request**
It was fetching an old variable which was removed on an PR. Just putting correct Variable fixed it!

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? 'YES'
- Does your code fit the style guidelines? 'YES'
- Does your PR fit the contribution guidelines? 'YES'
