### PR TITLE
Prevent runtime error on nil weapon (stuck in ragdoll)

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -109,8 +109,8 @@ AddEventHandler('gameEventTriggered', function(event, data)
                 local playerName = GetPlayerName(playerid) .. " " .. "("..GetPlayerServerId(playerid)..")" or Lang:t('info.self_death')
                 local killerId = NetworkGetPlayerIndexFromPed(attacker)
                 local killerName = GetPlayerName(killerId) .. " " .. "("..GetPlayerServerId(killerId)..")" or Lang:t('info.self_death')
-                local weaponLabel = QBCore.Shared.Weapons[weapon].label or 'Unknown'
-                local weaponName = QBCore.Shared.Weapons[weapon].name or 'Unknown'
+                local weaponLabel = (QBCore.Shared.Weapons and QBCore.Shared.Weapons[weapon] and QBCore.Shared.Weapons[weapon].label) or 'Unknown'
+                local weaponName = (QBCore.Shared.Weapons and QBCore.Shared.Weapons[weapon] and QBCore.Shared.Weapons[weapon].name) or 'Unknown'
                 TriggerServerEvent("qb-log:server:CreateLog", "death", Lang:t('logs.death_log_title', {playername = playerName, playerid = GetPlayerServerId(playerid)}), "red", Lang:t('logs.death_log_message', {killername = killerName, playername = playerName, weaponlabel = weaponLabel, weaponname = weaponName}))
                 deathTime = Config.DeathTime
                 OnDeath()


### PR DESCRIPTION
Prevents a runtime error if the weapon the ped is killed with is not in shared weapons. (or syntax error)
The error currently causes the ped to be stuck in ragdoll on death, which requires a manual revive and teleport to fix.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**

- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality? 
- [x] Does your code fit the style guidelines?
- [x] Does your PR fit the contribution guidelines?
