### PR TITLE
Load metadata "Health" and "Armor" when connecting.

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -98,8 +98,6 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     local player = PlayerId()
     CreateThread(function()
         Wait(5000)
-        SetEntityMaxHealth(ped, 200)
-        SetEntityHealth(ped, 200)
         SetPlayerHealthRechargeMultiplier(player, 0.0)
         SetPlayerHealthRechargeLimit(player, 0.0)
     end)
@@ -108,7 +106,8 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
         QBCore.Functions.GetPlayerData(function(PlayerData)
             PlayerJob = PlayerData.job
             onDuty = PlayerData.job.onduty
-            SetPedArmour(PlayerPedId(), PlayerData.metadata["armor"])
+            SetEntityHealth(ped, PlayerData.metadata["health"])
+            SetPedArmour(ped, PlayerData.metadata["armor"])
             if (not PlayerData.metadata["inlaststand"] and PlayerData.metadata["isdead"]) then
                 deathTime = Config.ReviveInterval
                 OnDeath()

--- a/client/main.lua
+++ b/client/main.lua
@@ -699,6 +699,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     local ped = PlayerPedId()
     TriggerServerEvent("hospital:server:SetDeathStatus", false)
     TriggerServerEvent('hospital:server:SetLaststandStatus', false)
+    TriggerServerEvent("hospital:server:SetHealth", GetEntityHealth(ped))
     TriggerServerEvent("hospital:server:SetArmor", GetPedArmour(ped))
     if bedOccupying then
         TriggerServerEvent("hospital:server:LeaveBed", bedOccupying)

--- a/server/main.lua
+++ b/server/main.lua
@@ -143,9 +143,23 @@ end)
 RegisterNetEvent('hospital:server:SetArmor', function(amount)
 	local src = source
 	local Player = QBCore.Functions.GetPlayer(src)
-	if Player then
-		Player.Functions.SetMetaData("armor", amount)
-	end
+    if not Player then return end
+    if amount <= 0 then
+       amount = 0
+    end
+    Player.Functions.SetMetaData('armor', amount)
+    Player.Functions.Save()
+end)
+
+RegisterNetEvent('hospital:server:SetHealth', function(amount)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    if amount <= 0 then
+       amount = 0
+    end
+    Player.Functions.SetMetaData('health', amount)
+    Player.Functions.Save()
 end)
 
 RegisterNetEvent('hospital:server:TreatWounds', function(playerId)


### PR DESCRIPTION
## Description

Load the metadata of "health" and "armor" when connecting.
This helps to keep the player's health and armor the same after reconnecting.

## Checklist

- [X] Have you personally loaded this code into an updated qbcore project and checked all it's functionality? (Be honest)
- [X] Does your code fit the style guidelines?
- [X] Does your PR fit the contribution guidelines?
