### PR TITLE
Fixed an issue where opening the pause menu just before death would prevent any action.

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -134,6 +134,9 @@ CreateThread(function()
         if isDead or InLaststand then
             sleep = 5
             local ped = PlayerPedId()
+            if IsPauseMenuActive() then
+                SetFrontendActive(false)
+            end
             DisableAllControlActions(0)
             EnableControlAction(0, 1, true)
             EnableControlAction(0, 2, true)


### PR DESCRIPTION
**Describe Pull request**
Fixed an issue where opening the pause menu just before death would prevent any action.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
