### PR TITLE
Fix armor not saving on exit

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -142,11 +142,14 @@ RegisterNetEvent('hospital:server:SetLaststandStatus', function(bool)
 end)
 
 RegisterNetEvent('hospital:server:SetArmor', function(amount)
-	local src = source
-	local Player = QBCore.Functions.GetPlayer(src)
-	if Player then
-		Player.Functions.SetMetaData('armor', amount)
-	end
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    if amount <= 0 then
+       amount = 0
+    end
+    Player.Functions.SetMetaData('armor', amount)
+    Player.Functions.Save()
 end)
 
 RegisterNetEvent('hospital:server:TreatWounds', function(playerId)


### PR DESCRIPTION
**Describe Pull Request**  
This PR updates the existing `hospital:server:SetArmor` event to ensure it correctly updates and saves a player's armor metadata in **qb-ambulancejob**. The update includes proper validation to prevent armor values from dropping below zero and ensures the metadata is saved after modification.  

These changes align with the new armor-saving feature in the core framework, ensuring smooth integration and preventing potential data inconsistencies.  

This update complements the PR submitted to the core repository for saving player armor when exiting the server. Please merge the core PR first to ensure compatibility.  

**Questions (please complete the following information):**  
- Have you personally loaded this code into an updated qbcore project and checked all its functionality? [yes]  
- Does your code fit the style guidelines? [yes]  
- Does your PR fit the contribution guidelines? [yes]  
