### PR TITLE
:art: Added Option For Spawning At Closest Hospital

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -639,21 +639,25 @@ end)
 RegisterNetEvent('hospital:client:RespawnAtHospital', function()
     local hospitalIndex = 1 -- Default hospital to respawn at
     if Config.RespawnAtNearestHospital and #Config.Locations["hospital"] > 0 then
-        local closestH = nil
-        local minDist = nil
-        for i=1, #Config.Locations["hospital"] do
-            if closestH then
-                local newDist = Vdist(Config.Locations["hospital"][i]["location"].x, Config.Locations["hospital"][i]["location"].y, Config.Locations["hospital"][i]["location"].z, GetEntityCoords(PlayerPedId()))
-                if newDist < minDist then
-                    closestH = i
-                    minDist = newDist
+        local closestHospital, lowestDist
+        local playerPed = PlayerPedId()
+        
+        if playerPed > 0 and DoesEntityExist(playerPed) then
+            local playerCoords = GetEntityCoords(playerPed)
+    
+            for i=1, #Config.Locations["hospital"] do
+                local dist = #(Config.Locations["hospital"][i]["location"] - playerCoords)
+                
+                if closestHospital == nil or dist < lowestDist then
+                    closestHospital = i
+                    lowestDist = dist
                 end
-            else
-                closestH = i
-                minDist = Vdist(Config.Locations["hospital"][i]["location"].x, Config.Locations["hospital"][i]["location"].y, Config.Locations["hospital"][i]["location"].z, GetEntityCoords(PlayerPedId()))
             end
         end
-        hospitalIndex = closestH
+        
+        if closestHospital ~= nil then
+            hospitalIndex = closestHospital
+        end
     end
     TriggerServerEvent('hospital:server:RespawnAtHospital', hospitalIndex)
     if exports['qb-policejob']:IsHandcuffed() then

--- a/client/main.lua
+++ b/client/main.lua
@@ -638,6 +638,23 @@ end)
 
 RegisterNetEvent('hospital:client:RespawnAtHospital', function()
     local hospitalIndex = 1 -- Default hospital to respawn at
+    if Config.RespawnAtNearestHospital and #Config.Locations["hospital"] > 0 then
+        local closestH = nil
+        local minDist = nil
+        for i=1, #Config.Locations["hospital"] do
+            if closestH then
+                local newDist = Vdist(Config.Locations["hospital"][i]["location"].x, Config.Locations["hospital"][i]["location"].y, Config.Locations["hospital"][i]["location"].z, GetEntityCoords(PlayerPedId()))
+                if newDist < minDist then
+                    closestH = i
+                    minDist = newDist
+                end
+            else
+                closestH = i
+                minDist = Vdist(Config.Locations["hospital"][i]["location"].x, Config.Locations["hospital"][i]["location"].y, Config.Locations["hospital"][i]["location"].z, GetEntityCoords(PlayerPedId()))
+            end
+        end
+        hospitalIndex = closestH
+    end
     TriggerServerEvent('hospital:server:RespawnAtHospital', hospitalIndex)
     if exports['qb-policejob']:IsHandcuffed() then
         TriggerEvent('police:client:GetCuffed', -1)

--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,7 @@ Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target in
 Config.MinimalDoctors = 2                                    -- How many players with the ambulance job to prevent the hospital check-in system from being used
 Config.DocCooldown = 1                                       -- Cooldown between doctor calls allowed, in minutes
 Config.WipeInventoryOnRespawn = true                         -- Enable or disable removing all the players items when they respawn at the hospital
+Config.RespawnAtNearestHospital = true                       -- Enable or disable respawning at the closest hospital
 Config.Helicopter = 'polmav'                                 -- Helicopter model that players with the ambulance job can use
 Config.BillCost = 2000                                       -- Price that players are charged for using the hospital check-in system
 Config.DeathTime = 300                                       -- How long the timer is for players to bleed out completely and respawn at the hospital


### PR DESCRIPTION
**Describe Pull request**
This PR allows for the option for servers to set respawning at the closest hospital instead of always using the default #1 hospital in the config. This will allow servers to have a more realistic hospital experience allowing them to configure more hospital locations and making them useful. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] 
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
