### PR TITLE
Remove armor handling from player load and unload events

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -120,7 +120,6 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
         QBCore.Functions.GetPlayerData(function(PlayerData)
             PlayerJob = PlayerData.job
             onDuty = PlayerData.job.onduty
-            SetPedArmour(PlayerPedId(), PlayerData.metadata['armor'])
             if (not PlayerData.metadata['inlaststand'] and PlayerData.metadata['isdead']) then
                 deathTime = Config.ReviveInterval
                 OnDeath()

--- a/client/main.lua
+++ b/client/main.lua
@@ -696,7 +696,6 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     local ped = PlayerPedId()
     TriggerServerEvent('hospital:server:SetDeathStatus', false)
     TriggerServerEvent('hospital:server:SetLaststandStatus', false)
-    TriggerServerEvent('hospital:server:SetArmor', GetPedArmour(ped))
     if bedOccupying then
         TriggerServerEvent('hospital:server:LeaveBed', bedOccupying, hospitalLocation)
     end
@@ -789,9 +788,6 @@ CreateThread(function()
                     if weapon then
                         if armorDamaged and (bodypart == 'SPINE' or bodypart == 'UPPER_BODY') or weapon == Config.WeaponClasses['NOTHING'] then
                             checkDamage = false -- Don't check damage if the it was a body shot and the weapon class isn't that strong
-                            if armorDamaged then
-                                TriggerServerEvent('hospital:server:SetArmor', GetPedArmour(ped))
-                            end
                         end
 
                         if checkDamage then

--- a/server/main.lua
+++ b/server/main.lua
@@ -141,14 +141,6 @@ RegisterNetEvent('hospital:server:SetLaststandStatus', function(bool)
 	end
 end)
 
-RegisterNetEvent('hospital:server:SetArmor', function(amount)
-	local src = source
-	local Player = QBCore.Functions.GetPlayer(src)
-	if Player then
-		Player.Functions.SetMetaData('armor', amount)
-	end
-end)
-
 RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
 	local src = source
 	local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
**Describe Pull request**
Removed armor handling from ambulance job, to do it in the core. (Should be merged with [qb-core #1164](https://github.com/qbcore-framework/qb-core/pull/1164))

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? no (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
