### PR TITLE
Always update player armor metadata

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -789,9 +789,6 @@ CreateThread(function()
                     if weapon then
                         if armorDamaged and (bodypart == 'SPINE' or bodypart == 'UPPER_BODY') or weapon == Config.WeaponClasses['NOTHING'] then
                             checkDamage = false -- Don't check damage if the it was a body shot and the weapon class isn't that strong
-                            if armorDamaged then
-                                TriggerServerEvent('hospital:server:SetArmor', GetPedArmour(ped))
-                            end
                         end
 
                         if checkDamage then
@@ -811,6 +808,10 @@ CreateThread(function()
             end
 
             CheckWeaponDamage(ped)
+        end
+
+        if playerArmor ~= armor then
+            TriggerServerEvent('hospital:server:SetArmor', GetPedArmour(ped))
         end
 
         playerHealth = health


### PR DESCRIPTION
This goes hand-in-hand with my PR to fix the initial armor saving when item is used: https://github.com/qbcore-framework/qb-smallresources/pull/497

Also fixes [qb-smallresources/195](https://github.com/qbcore-framework/qb-smallresources/issues/195)

Moves the update of the player's armor outside of the multiple if checks that wouldn't trigger if only the player's armor takes a hit. Now it will always update the player's armor metadata value if their armor value has changed from the last iteration. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**
