### PR TITLE
fix: remove auto-ban on firstaid usage to prevent false positives

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -210,17 +210,9 @@ RegisterNetEvent('hospital:server:RevivePlayer', function(playerId, isOldMan)
 				TriggerClientEvent('hospital:client:Revive', Patient.PlayerData.source)
 			end
 		else
-			MySQL.insert('INSERT INTO bans (name, license, discord, ip, reason, expire, bannedby) VALUES (?, ?, ?, ?, ?, ?, ?)', {
-				GetPlayerName(src),
-				QBCore.Functions.GetIdentifier(src, 'license'),
-				QBCore.Functions.GetIdentifier(src, 'discord'),
-				QBCore.Functions.GetIdentifier(src, 'ip'),
-				'Trying to revive theirselves or other players',
-				2147483647,
-				'qb-ambulancejob'
-			})
-			TriggerEvent('qb-log:server:CreateLog', 'ambulancejob', 'Player Banned', 'red', string.format('%s was banned by %s for %s', GetPlayerName(src), 'qb-ambulancejob', 'Trying to revive theirselves or other players'), true)
-			DropPlayer(src, 'You were permanently banned by the server for: Exploiting')
+			-- Log suspicious activity instead of auto-banning to prevent false positives from inventory sync issues
+			TriggerEvent('qb-log:server:CreateLog', 'ambulancejob', 'Unauthorized Revive Attempt', 'orange', string.format('%s attempted to revive without proper job or firstaid item (possible inventory desync)', GetPlayerName(src)), false)
+			TriggerClientEvent('QBCore:Notify', src, Lang:t('error.no_firstaid'), 'error')
 		end
 	end
 end)


### PR DESCRIPTION
Replaced automatic permanent ban with logging and error notification when firstaid item check fails. This prevents legitimate players from being banned due to inventory synchronization issues.

The previous implementation would ban players if the firstaid item wasn't detected server-side after the 5-second progress bar, which could occur due to race conditions in the inventory system rather than actual exploit attempts.

Changes:
- Replaced permanent ban with warning-level log entry
- Added notification to player instead of kicking them
- Included note about possible inventory desync in logs

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
